### PR TITLE
Add Jekyll site instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Personal Site built with Jekyll and Octopress
+
+This repository hosts the source of my personal blog powered by **Jekyll** with the **Octopress** framework. Here I share travel stories, coding tutorials and showcase some of my applications.
+
+## Install Dependencies
+
+Use Bundler and npm to fetch the Ruby and Node packages required by the site:
+
+```bash
+bundle install
+npm install
+```
+
+## Local Development
+
+Run the Jekyll server to build the site and watch for changes:
+
+```bash
+jekyll serve
+```
+
+The site will be available at `http://localhost:4000` by default.
+
+## Deploy to GitHub Pages
+
+Commit your changes and push them to the GitHub repository. GitHub Pages will automatically build the site and publish it live.


### PR DESCRIPTION
## Summary
- document this site's Jekyll + Octopress setup
- explain how to install dependencies
- show how to build locally with `jekyll serve`
- note that GitHub Pages handles deployment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684db3caadc883228be9827fe9767a21